### PR TITLE
Minor cleanup: rename and add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# CHANGELOG
+
+The changelog is continuous. All changes are made to the current version branch.
+
+## v1
+
+- Rename from 'globus/reusable-workflows' to 'globus/workflows'

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ on:
   pull_request:
 jobs:
   lint:
-    uses: globus/reusable-workflows/.github/workflows/run_tox.yaml@v1
+    uses: globus/workflows/.github/workflows/run_tox.yaml@v1
     with:
       python-version: "3.10"
       tox-env: lint
@@ -49,7 +49,7 @@ on:
 
 jobs:
   check_changelog:
-    uses: globus/reusable-workflows/.github/workflows/pr_has_changelog.yaml@v1
+    uses: globus/workflows/.github/workflows/pr_has_changelog.yaml@v1
 ```
 
 ## Versioning


### PR DESCRIPTION
- Rename 'reusable-workflows' to 'workflows'
- Introduce a changelog file

---

This is a pair of very minor changes to try to put this repo on good footing, regardless of its content.
