### PR TITLE
Release v1.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: "trailing-whitespace"
 
   - repo: "https://github.com/sirosen/check-jsonschema"
-    rev: "0.30.0"
+    rev: "0.31.2"
     hooks:
       - id: "check-github-workflows"
 
@@ -27,6 +27,6 @@ repos:
       - id: "forbid-bidi-controls"
 
   - repo: "https://github.com/rhysd/actionlint"
-    rev: "v1.7.6"
+    rev: "v1.7.7"
     hooks:
       - id: "actionlint"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The changelog is continuous. All changes are made to the current version branch.
 
+## v1.2
+
+- Update `actions/cache` versions to resolve test suite failures.
+
 ## v1
 
 - Rename from 'globus/reusable-workflows' to 'globus/workflows'

--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ on:
 
 jobs:
   check_changelog:
-    uses: globus/workflows/.github/workflows/pr_has_changelog.yaml@v1.0
+    uses: globus/workflows/.github/workflows/pr_has_changelog.yaml@v1
 ```


### PR DESCRIPTION
This release is mandatory for the benefit of downstream repos that rely on these reusable workflows.

In particular, v1.2 includes upgrades to the `actions/cache` version, which urgently needs to be released because GitHub has disabled all old versions.