### PR TITLE
Enhance the "has changelog" workflow with inputs

### DIFF
--- a/.github/workflows/pr_has_changelog.yaml
+++ b/.github/workflows/pr_has_changelog.yaml
@@ -10,12 +10,9 @@ on:
         type: 'string'
 
       changelog-type:
-        description: 'Markdown or Restructured Text'
-        type: 'choice'
+        description: 'The file extension used for changelog items (e.g., "md" or "rst").'
+        type: 'string'
         default: 'md'
-        options:
-          - 'md'
-          - 'rst'
 
       base-branch:
         description: 'The branch against which the changelog comparison is run.'


### PR DESCRIPTION
This brings the workflow up to parity with the versions which we are
actively using in other projects.

- The workflow can now skip a list of (bot) users' PRs
- The workflow can choose between `rst` and `md` docs
- A `base-branch` can be configured to support repos where `main` is
  not the base branch (this was noted for future customization in the
  workflow itself)
