### PR TITLE
Support configuring tox environments to skip

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -1,6 +1,6 @@
 # This file is a part of Kurt McKee's GitHub Workflows project.
 # https://github.com/kurtmckee/github-workflows
-# Copyright 2024 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2024-2025 Kurt McKee <contactme@kurtmckee.org>
 # SPDX-License-Identifier: MIT
 
 on:
@@ -11,6 +11,9 @@ on:
           The configuration object.
         required: true
         type: "string"
+
+env:
+  CHECK_JSONSCHEMA_VERSION: "0.34.0"
 
 jobs:
   tox:
@@ -25,6 +28,11 @@ jobs:
           inputs_config: "${{ inputs.config }}"
         run: |
           echo "$inputs_config" > ".tox-config.raw.json"
+
+      - name: "Setup Python for tox config validation/transformation"
+        uses: "actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c" # v6.0.0
+        with:
+          python-version: "3.13"
 
       # If a previous workflow run successfully validated an identical config object,
       # a cache hit is sufficient to demonstrate that no further validation is required.
@@ -44,6 +52,7 @@ jobs:
             # START: tox-schema.json
             {
               "$schema": "https://json-schema.org/draft-07/schema",
+              "description": "This file is a part of Kurt McKee's GitHub Workflows project.\nhttps://github.com/kurtmckee/github-workflows\nCopyright 2024-2025 Kurt McKee <contactme@kurtmckee.org>.\nSPDX-License-Identifier: MIT",
               "type": "object",
               "required": [
                 "runner"
@@ -54,7 +63,22 @@ jobs:
                   "minLength": 1
                 },
                 "tox-environments": {
-                  "$comment": "A list of tox environments to run.",
+                  "description": "A list of tox environments to run.",
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "tox-skip-environments-regex": {
+                  "description": "A regular expression matching tox environments to skip.",
+                  "type": "string",
+                  "format": "regex",
+                  "minLength": 1
+                },
+                "tox-skip-environments": {
+                  "description": "A list of tox environments to skip.",
                   "type": "array",
                   "minItems": 1,
                   "items": {
@@ -63,12 +87,12 @@ jobs:
                   }
                 },
                 "tox-environments-from-pythons": {
-                  "$comment": "Generate a list of tox environments from the list of all configured Python interpreters.",
+                  "description": "Generate a list of tox environments from the list of all configured Python interpreters.",
                   "type": "boolean",
                   "enum": [true]
                 },
                 "tox-factors": {
-                  "$comment": "A list of factors to append to the generated names of tox environments.",
+                  "description": "A list of factors to append to the generated names of tox environments.",
                   "type": "array",
                   "minItems": 1,
                   "items": {
@@ -77,7 +101,7 @@ jobs:
                   }
                 },
                 "tox-pre-environments": {
-                  "$comment": "A list of tox environments to run before all installed Python interpreter versions.",
+                  "description": "A list of tox environments to run before all installed Python interpreter versions.",
                   "type": "array",
                   "minItems": 1,
                   "items": {
@@ -86,7 +110,7 @@ jobs:
                   }
                 },
                 "tox-post-environments": {
-                  "$comment": "A list of tox environments to run after all installed Python interpreter versions.",
+                  "description": "A list of tox environments to run after all installed Python interpreter versions.",
                   "type": "array",
                   "minItems": 1,
                   "items": {
@@ -95,7 +119,7 @@ jobs:
                   }
                 },
                 "cpythons": {
-                  "$comment": "A list of CPython interpreter versions. Typically, the *last version* listed will be the default Python interpreter when 'python' is invoked, and will be the version used when installing and executing tox.",
+                  "description": "A list of CPython interpreter versions. Typically, the *last version* listed will be the default Python interpreter when 'python' is invoked, and will be the version used when installing and executing tox.",
                   "type": "array",
                   "minItems": 1,
                   "items": {
@@ -104,12 +128,12 @@ jobs:
                   }
                 },
                 "cpython-beta": {
-                  "$comment": "A CPython version to install as a beta. Unless the 'cpythons' list is empty, this version will never be the default Python interpreter.",
+                  "description": "A CPython version to install as a beta. Unless the 'cpythons' list is empty, this version will never be the default Python interpreter.",
                   "type": "string",
                   "minLength": 3
                 },
                 "pypys": {
-                  "$comment": "A list of PyPy interpreter versions.",
+                  "description": "A list of PyPy interpreter versions.",
                   "type": "array",
                   "minItems": 1,
                   "items": {
@@ -118,13 +142,13 @@ jobs:
                   }
                 },
                 "cache-key-prefix": {
-                  "$comment": "A prefix to use with the cached environment key.",
+                  "description": "A prefix to use with the cached environment key.",
                   "type": "string",
                   "minLength": 1,
                   "default": "tox"
                 },
                 "cache-key-hash-files": {
-                  "$comment": "An additional path pattern that will be added to the list of paths to include when hashing files for cache-busting.",
+                  "description": "An additional path pattern that will be added to the list of paths to include when hashing files for cache-busting.",
                   "type": "array",
                   "minItems": 1,
                   "items": {
@@ -133,7 +157,7 @@ jobs:
                   }
                 },
                 "cache-paths": {
-                  "$comment": "Additional paths to cache. Any paths specified here will be added to the default list: '.venv/' and '.tox/'.",
+                  "description": "Additional paths to cache. Any paths specified here will be added to the default list: '.venv/' and '.tox/'.",
                   "type": "array",
                   "minItems": 1,
                   "items": {
@@ -144,7 +168,7 @@ jobs:
               },
               "allOf": [
                 {
-                  "$comment": "At least one Python interpreter must be present.",
+                  "description": "At least one Python interpreter must be specified.",
                   "anyOf": [
                     {"required": ["cpythons"]},
                     {"required": ["cpython-beta"]},
@@ -152,24 +176,33 @@ jobs:
                   ]
                 },
                 {
+                  "description": "If tox-environments is specified, many other keys must not be specified.",
                   "if": {"required": ["tox-environments"]},
                   "then": {
                     "allOf": [
                       {
-                        "$comment": "tox-environments is mutually exclusive with tox-environments-from-pythons.",
+                        "description": "tox-environments is mutually exclusive with tox-environments-from-pythons.",
                         "not": {"required": ["tox-environments-from-pythons"]}
                       },
                       {
-                        "$comment": "tox-environments is mutually exclusive with tox-factors.",
+                        "description": "tox-environments is mutually exclusive with tox-factors.",
                         "not": {"required": ["tox-factors"]}
                       },
                       {
-                        "$comment": "tox-environments is mutually exclusive with tox-pre-environments.",
+                        "description": "tox-environments is mutually exclusive with tox-pre-environments.",
                         "not": {"required": ["tox-pre-environments"]}
                       },
                       {
-                        "$comment": "tox-environments is mutually exclusive with tox-post-environments.",
+                        "description": "tox-environments is mutually exclusive with tox-post-environments.",
                         "not": {"required": ["tox-post-environments"]}
+                      },
+                      {
+                        "description": "tox-environments is mutually exclusive with tox-skip-environments.",
+                        "not": {"required": ["tox-skip-environments"]}
+                      },
+                      {
+                        "description": "tox-environments is mutually exclusive with tox-skip-environments-regex.",
+                        "not": {"required": ["tox-skip-environments-regex"]}
                       }
                     ]
                   }
@@ -182,18 +215,16 @@ jobs:
           # the START and END lines in the JSON schema above must be removed.
           echo "${tox_schema}" | grep -ve '^#' > "${RUNNER_TEMP}/tox-schema.json"
 
-      - name: "Setup Python for tox config validation"
-        if: "steps.lookup-config-cache.outputs.cache-hit == false"
-        uses: "actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c" # v6.0.0
-        with:
-          python-version: "3.12"
-
       - name: "Validate the raw tox config against the schema"
         if: "steps.lookup-config-cache.outputs.cache-hit == false"
         shell: "bash"
         run: |
-          pip install --target="${RUNNER_TEMP}/check-jsonschema" check-jsonschema
-          PYTHONPATH="${RUNNER_TEMP}/check-jsonschema" "${RUNNER_TEMP}/check-jsonschema/bin/check-jsonschema" --schemafile "${RUNNER_TEMP}/tox-schema.json" ".tox-config.raw.json"
+          pip install --target="${RUNNER_TEMP}/check-jsonschema" "check-jsonschema==${CHECK_JSONSCHEMA_VERSION}"
+          export PYTHONPATH="${RUNNER_TEMP}/check-jsonschema"
+          "${RUNNER_TEMP}/check-jsonschema/bin/check-jsonschema" \
+              --schemafile "${RUNNER_TEMP}/tox-schema.json" \
+              --regex-variant python \
+              ".tox-config.raw.json"
 
       - name: "Create a 'config-is-validated' cache key"
         if: "steps.lookup-config-cache.outputs.cache-hit == false"
@@ -210,10 +241,11 @@ jobs:
           import json
           import os
           import pathlib
+          import re
           import typing
 
 
-          def transform_config(config: dict[str, typing.Any]):
+          def transform_config(config: dict[str, typing.Any]) -> None:
               # Transform the tox environments for convenience.
               # pre- and post-environments will be assembled into "tox-environments",
               # together with a full list of CPython and PyPy interpreter versions.
@@ -248,10 +280,18 @@ jobs:
               # a stable CPython version must be included during initial Python setup.
               python_versions_required = python_versions_requested.copy()
               if not cpythons:
-                  python_versions_required.append("3.12")
-
+                  python_versions_required.append("3.13")
               config["python-versions-requested"] = "\n".join(python_versions_requested)
               config["python-versions-required"] = "\n".join(python_versions_required)
+
+              # Prepare the environments to skip.
+              skip_patterns: list[str] = []
+              for environment in config.pop("tox-skip-environments", []):
+                  skip_patterns.append(re.escape(environment))
+              skip_patterns.sort()
+              if pattern := config.pop("tox-skip-environments-regex", ""):
+                  skip_patterns.append(pattern)
+              config["tox-skip-environments-regex"] = "|".join(skip_patterns)
 
 
           def main() -> None:
@@ -352,5 +392,7 @@ jobs:
           allow-prereleases: true
 
       - name: "Run the test suite"
+        env:
+          TOX_SKIP_ENV: "${{ fromJSON(env.tox-config).tox-skip-environments-regex }}"
         run: |
           ${{ env.venv-path }}/tox run --colored yes ${{ fromJSON(env.tox-config).tox-environments && format('-e "{0}"', join(fromJSON(env.tox-config).tox-environments, ',')) }}


### PR DESCRIPTION
This is a copy of the v1.5 kurtmckee/github-workflows `tox.yaml` file.

* It switches from `$comment` to `description` in the schema.
* It ensures a known-good Python version is used when transforming the config JSON.
* It supports skipping tox environments based on new `tox-skip-environments` and `tox-skip-environments-regex` keys.